### PR TITLE
chore: sync with upstream pnpm/action-setup v4.4.0

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,6 @@ outputs:
   bin_dest:
     description: Location of `pnpm` and `pnpx` command
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
   post: dist/index.js

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@actions/exec": "^1.1.1",
     "@actions/glob": "^0.5.0",
     "@types/expand-tilde": "^2.0.2",
-    "@types/node": "^20.11.5",
+    "@types/node": "^22.0.0",
     "expand-tilde": "^2.0.2",
     "yaml": "^2.3.4",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       '@types/node':
-        specifier: ^20.11.5
-        version: 20.17.17
+        specifier: ^22.0.0
+        version: 22.19.21
       expand-tilde:
         specifier: ^2.0.2
         version: 2.0.2
@@ -207,8 +207,8 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/node@20.17.17':
-    resolution: {integrity: sha512-/WndGO4kIfMicEQLTi/mDANUu/iVUhT7KboZPdEqqHQ4aTS+3qT3U5gIqWDFV+XouorjfgGqvKILJeHhuQgFYg==}
+  '@types/node@22.19.21':
+    resolution: {integrity: sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==}
 
   '@typescript-eslint/eslint-plugin@8.55.0':
     resolution: {integrity: sha512-1y/MVSz0NglV1ijHC8OT49mPJ4qhPYjiK08YUQVbIOyu+5k862LKUHFkpKHWu//zmr7hDR2rhwUm6gnCGNmGBQ==}
@@ -749,8 +749,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@6.19.8:
-    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici@7.22.0:
     resolution: {integrity: sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==}
@@ -1028,9 +1028,9 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/node@20.17.17':
+  '@types/node@22.19.21':
     dependencies:
-      undici-types: 6.19.8
+      undici-types: 6.21.0
 
   '@typescript-eslint/eslint-plugin@8.55.0(@typescript-eslint/parser@8.55.0(eslint@9.39.2)(typescript@5.7.3))(eslint@9.39.2)(typescript@5.7.3)':
     dependencies:
@@ -1565,7 +1565,7 @@ snapshots:
 
   typescript@5.7.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.21.0: {}
 
   undici@7.22.0: {}
 


### PR DESCRIPTION
## Summary

Syncs the fork with upstream [pnpm/action-setup v4.4.0](https://github.com/pnpm/action-setup/releases/tag/v4.4.0), which moves the action runtime from **node20 to node24**. GitHub forces the Node 24 runtime on **2026-06-16**; every consumer currently gets node20 deprecation annotations on every run.

## Changes

- `action.yml`: `runs.using: node20` → `node24` (the upstream v4.4.0 change)
- `package.json`: `@types/node` `^20.11.5` → `^22.0.0` (upstream v4.4.0)
- `pnpm-lock.yaml`: lockfile refresh for the types bump
- `dist/index.js`: **unchanged** — local rebuild is byte-identical; the types-only bump does not affect the bundle

Fork-specific changes (eslint setup, pnpm security overrides, engines field) are preserved.

## After merge

Tag the merge commit as `v4.4.0` and move `v4` to it. Consumers (selara.io, guild-os, and the other SIG repos pinning `@4779877`) will bump to the new immutable SHA.